### PR TITLE
Tdex cli install from npm

### DIFF
--- a/tdex-cli.md
+++ b/tdex-cli.md
@@ -1,17 +1,20 @@
 # 💻 TDEX CLI
 Command line interface for making swaps and trades on TDEX
 
-## Install
+**⬇️ Install from NPM**
 
-**Install from NPM**
-
+* Install with **yarn**
 
 ```sh
-# With Yarn
 $ yarn global add tdex-cli
-# With NPM
+```
+
+* Install with **npm**
+
+```sh
 $ npm i -g tdex-cli
 ```
+
 
 **Standalone binary (node/npm not needed)**
 

--- a/tdex-cli.md
+++ b/tdex-cli.md
@@ -5,7 +5,13 @@ Command line interface for making swaps and trades on TDEX
 
 **Install from NPM**
 
-Not published yet.
+
+```sh
+# With Yarn
+$ yarn global add tdex-cli
+# With NPM
+$ npm i -g tdex-cli
+```
 
 **Standalone binary (node/npm not needed)**
 

--- a/tdex-sdk.md
+++ b/tdex-sdk.md
@@ -8,11 +8,15 @@ JavaScript SDK for building trader-facing applications on top of TDEX
 
 * Install with **yarn**
 
-Not published yet.
+```sh
+$ yarn add tdex-sdk
+```
 
 * Install with **npm**
 
-Not published yet.
+```sh
+$ npm install --save tdex-sdk
+```
 
 ### 📄 Usage
 
@@ -24,16 +28,30 @@ Trade against a Liquidity provider in the TDEX network. This fully implements [*
 ```js
 import { Trade } from 'tdex-sdk';
 
+// Connect to specific provider and use Blockstream as explorer endpoint.
 const trade = new Trade({
   chain: 'liquid',
-  providerUrl: 'https://tdex.vulpem.com',
+  providerUrl: 'alpha-provider.tdex.network',
   explorerUrl: 'https://blockstream.info/liquid/api',
 });
 
 const LBTC = '6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d';
 const USDT = 'c5870288a7c9eb5db398a5b5e7221feb9753134439e8ed9f569b0eea5a423330';
 const WIF = "...";
+
+// Buy some LBTCs
 trade.buy({
+  market: {
+    baseAsset: LBTC,
+    quoteAsset: USDT,
+  },
+  amount: 0.001,
+  address: 'ex1q583qjfp8pd8wdxh6t6fc6cw536kt3l5t0lz2ua',
+  privateKey: WIF
+});
+
+// Or sell some LBTCs
+trade.sell({
   market: {
     baseAsset: LBTC,
     quoteAsset: USDT,


### PR DESCRIPTION
This commit updates the installation instructions to pull CLI and SDK from NPM. SDK Usage has been integrated with the `trade.sell` API.